### PR TITLE
🐛 Bug - AIReport에서 UserId 매핑 문제를 해결한다

### DIFF
--- a/src/main/java/sopt/comfit/report/domain/AIReportRepository.java
+++ b/src/main/java/sopt/comfit/report/domain/AIReportRepository.java
@@ -24,5 +24,5 @@ public interface AIReportRepository extends JpaRepository<AIReport, Long> {
     );
 
     Optional<AIReport> findByExperienceUserIdAndId(Long userId, Long id);
-    boolean existsByCompanyIdAndUserId(Long companyId, Long userId);
+    boolean existsByCompanyIdAndExperienceUserId(Long companyId, Long userId);
 }

--- a/src/main/java/sopt/comfit/user/service/UserService.java
+++ b/src/main/java/sopt/comfit/user/service/UserService.java
@@ -50,7 +50,7 @@ public class UserService {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> BaseException.type(CompanyErrorCode.COMPANY_NOT_FOUND));
 
-        boolean isConnected = aIReportRepository.existsByCompanyIdAndUserId(companyId, userId);
+        boolean isConnected = aIReportRepository.existsByCompanyIdAndExperienceUserId(companyId, userId);
         UserCompany userCompany = userCompanyRepository.save(UserCompany.create(user, company, isConnected));
         return userCompany.getId();
     }


### PR DESCRIPTION
## 📌 요약
AIReport에서 UserId 매핑 문제를 해결한다

## 📝 변경 내용
`existsByCompanyIdAndExperienceUserId` 메서드 명 수정했어요 UserId 매핑 할 필요 없어서 experience 만 연결했습니다
 오류생겨서 메스드 명 수정했습니다

## ✅ 체크리스트
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## 🗣 의견 / 공유 해야하는 점

## 🚪 연관 이슈 번호
Closes #12 