### PR TITLE
🐛 Bug - Token이 있는 경우에 Authentication 객체를 반환하지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/sopt/comfit/company/controller/CompanyController.java
+++ b/src/main/java/sopt/comfit/company/controller/CompanyController.java
@@ -1,13 +1,12 @@
 package sopt.comfit.company.controller;
 
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import sopt.comfit.company.domain.EScale;
 import sopt.comfit.company.dto.response.*;
 import sopt.comfit.company.service.CompanyService;
@@ -16,6 +15,7 @@ import sopt.comfit.global.dto.PageDto;
 import sopt.comfit.global.enums.EIndustry;
 import sopt.comfit.global.enums.ESort;
 
+import java.util.List;
 @RestController
 @RequestMapping("/api/v1/companies")
 @RequiredArgsConstructor

--- a/src/main/java/sopt/comfit/global/config/WebConfig.java
+++ b/src/main/java/sopt/comfit/global/config/WebConfig.java
@@ -29,6 +29,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new UserInterceptor())
                 .addPathPatterns("/**")
-                .excludePathPatterns(Constants.NO_NEED_AUTH);
+                .excludePathPatterns(Constants.NO_NEED_AUTH_INTERCEPTOR);
     }
 }

--- a/src/main/java/sopt/comfit/global/constants/Constants.java
+++ b/src/main/java/sopt/comfit/global/constants/Constants.java
@@ -30,4 +30,21 @@ public class Constants {
             "/.well-known/**",
             "/api/v1/companies/**"
     );
+
+    public static List<String> NO_NEED_AUTH_INTERCEPTOR = List.of(
+            "/swagger",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api-docs",
+            "/api-docs/**",
+            "/v3/api-docs/**",
+            "/api/health",
+            "/api/health-check",
+            "/api/v1/login",
+            "/api/v1/re-issued",
+            "/actuator/**",
+            "/api/v1/oauth/kakao/callback",
+            "/favicon.ico",
+            "/.well-known/**"
+    );
 }

--- a/src/main/java/sopt/comfit/global/interceptor/pre/UserInterceptor.java
+++ b/src/main/java/sopt/comfit/global/interceptor/pre/UserInterceptor.java
@@ -12,6 +12,7 @@ public class UserInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.info("authentication:{}",authentication.getName());
         request.setAttribute("USER_ID", Long.valueOf(authentication.getName()));
         return HandlerInterceptor.super.preHandle(request, response, handler);
     }

--- a/src/main/java/sopt/comfit/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/comfit/global/security/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        log.info(request.getHeader(Constants.PREFIX_AUTH));
+
+
+        String header = request.getHeader(Constants.PREFIX_AUTH);
+        log.info("header:{}",header);
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         String token = HeaderUtil.refineHeader(request, Constants.PREFIX_AUTH, Constants.BEARER);
         Claims claim = jwtUtil.validateToken(token);
         log.info("claim: getUserId() = {}", claim.get(Constants.CLAIM_USER_ID, Long.class));
@@ -54,10 +62,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return Constants.NO_NEED_AUTH.stream()
-                .anyMatch(patter -> Constants.PATH_MATCHER.match(patter, request.getRequestURI()));
-
-    }
 }


### PR DESCRIPTION
## 📌 요약
Token이 있는 경우에 Authentication 객체를 반환하지 않는 문제를 해결한다

## 📝 변경 내용
`ShouldNotFilter`를 제거한 후에 JwtAuthentication에서 헤더가 없는 경우에는 리턴 후, 화이트리스트에서 판단, 헤더가있는 경우에는 Authentication 객체를 만드는 로직으로 변경

Interceptor에서 화이트리스트인 경우는 interceptor를 거치지않는 구조로 설계되었는데, 화이트리스트인 경우와 인증이 필요한 경로의 분기를 통해서 interceptor에 거치도록 설계

## ✅ 체크리스트
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## 🗣 의견 / 공유 해야하는 점

## 🚪 연관 이슈 번호
Closes #41 