### PR TITLE
🐛 Bug - UserInterceptor 서버 오류를 고친다

### DIFF
--- a/src/main/java/sopt/comfit/global/interceptor/pre/UserInterceptor.java
+++ b/src/main/java/sopt/comfit/global/interceptor/pre/UserInterceptor.java
@@ -3,6 +3,7 @@ package sopt.comfit.global.interceptor.pre;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -12,8 +13,11 @@ public class UserInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        log.info("authentication:{}",authentication.getName());
-        request.setAttribute("USER_ID", Long.valueOf(authentication.getName()));
-        return HandlerInterceptor.super.preHandle(request, response, handler);
+        log.info("authentication:{}", authentication.getName());
+        if (!(authentication instanceof AnonymousAuthenticationToken)) {
+            request.setAttribute("USER_ID", Long.valueOf(authentication.getName()));
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## 📌 요약
UserInterceptor 서버 오류를 고친다

## 📝 변경 내용
Authentication 이 없는 경우에 익명유저 반환해서 Long.valueOf에서 오류가 터지는 상황
방지하도록 if조건문 걸었습니다

## ✅ 체크리스트
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## 🗣 의견 / 공유 해야하는 점

## 🚪 연관 이슈 번호
Closes #44 