### PR TITLE
♻️ Refactor - 전체 가상스레드 전환으로 OpenFeign 방식에서의 최적의 RateLimiter를 찾는다

### DIFF
--- a/src/main/java/sopt/comfit/report/infra/feign/ResilientOpenAiFeignClient.java
+++ b/src/main/java/sopt/comfit/report/infra/feign/ResilientOpenAiFeignClient.java
@@ -2,6 +2,7 @@ package sopt.comfit.report.infra.feign;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class ResilientOpenAiFeignClient {
     private final OpenAiFeignClient openAiFeignClient;
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 
+    @RateLimiter(name = "openai")
     @io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker(
             name = "openai-feign", fallbackMethod = "createReportFallback")
     @Retry(name = "openai-feign")


### PR DESCRIPTION
## 📌 요약
OpenFeign 방식에다가도 RateLimiter를 넣었습니다

## 📝 변경 내용
가상스레드를 도입하면서 전체 요청이 빨라짐에 따라 OpenFeign에 가상스레드 방식에서도 서킷브레이커가 열리는문제
이를 해결하기 위해 RateLimiter를 OpenFeign에도 적용했습니다


## ✅ 체크리스트
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## 🗣 의견 / 공유 해야하는 점

## 🚪 연관 이슈 번호
Closes #83 