### PR TITLE
🐛 Bug - Security Filter를 리팩토링하여 액세스 토큰 재발급 로직에서 발생하는 오류를 수정한다

### DIFF
--- a/src/main/java/sopt/comfit/auth/controller/AuthController.java
+++ b/src/main/java/sopt/comfit/auth/controller/AuthController.java
@@ -1,18 +1,16 @@
 package sopt.comfit.auth.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import sopt.comfit.auth.dto.AccessTokenResponseDto;
 import sopt.comfit.auth.dto.LoginResponseDto;
-import sopt.comfit.auth.dto.ReIssueTokenResponseDto;
 import sopt.comfit.auth.dto.command.LoginCommandDto;
 import sopt.comfit.auth.dto.command.OnBoardingCommandDto;
 import sopt.comfit.auth.dto.query.LoginQueryDto;
 import sopt.comfit.auth.dto.request.LoginRequestDto;
 import sopt.comfit.auth.dto.request.OnBoardingRequestDTO;
-import sopt.comfit.auth.dto.request.ReIssueTokenRequestDto;
 import sopt.comfit.auth.kakao.service.KakaoAuthService;
 import sopt.comfit.auth.service.AuthService;
 import sopt.comfit.global.annotation.LoginUser;
@@ -28,23 +26,41 @@ public class AuthController implements AuthSwagger{
 
     @PostMapping("/login")
     public JwtDto join(
-            @RequestBody @Valid LoginRequestDto request
+            @RequestBody @Valid LoginRequestDto request,
+            HttpServletResponse response
     ){
-        return authService.login(LoginCommandDto.from(request));
+        JwtDto dto = authService.login(LoginCommandDto.from(request));
+
+        response.addHeader("Set-Cookie",
+                "refreshToken=" + dto.refreshToken() +
+                        "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=86400");
+
+        return dto;
     }
 
     @Override
     public void logout(
-            @LoginUser Long userId
+            @LoginUser Long userId,
+            HttpServletResponse response
     ){
         authService.logout(userId);
+
+        response.addHeader("Set-Cookie",
+                "refreshToken=; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=0");
     }
 
     @Override
-    public ReIssueTokenResponseDto reissueToken(
-            @RequestBody @Valid ReIssueTokenRequestDto request
+    public AccessTokenResponseDto reissueToken(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
     ) {
-        return authService.reissueToken(request.refreshToken());
+        JwtDto dto = authService.reissueToken(refreshToken);
+
+        response.addHeader("Set-Cookie",
+                "refreshToken=" + dto.refreshToken() +
+                        "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=86400");
+
+        return AccessTokenResponseDto.from(dto.accessToken());
     }
 
     @Override
@@ -62,11 +78,9 @@ public class AuthController implements AuthSwagger{
     ) {
         LoginQueryDto loginQueryDto = kakaoAuthService.getKakaoUserInfoByCode(code);
 
-        Cookie cookie = new Cookie("refreshToken", loginQueryDto.jwtDto().refreshToken());
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(7 * 24 * 60 * 60); // 7일 (refreshToken 만료와 맞춰서 조정)
-        response.addCookie(cookie);
+        response.addHeader("Set-Cookie",
+                "refreshToken=" + loginQueryDto.jwtDto().refreshToken() +
+                        "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=86400");
 
         return LoginResponseDto.of(loginQueryDto);
     }

--- a/src/main/java/sopt/comfit/auth/controller/AuthSwagger.java
+++ b/src/main/java/sopt/comfit/auth/controller/AuthSwagger.java
@@ -9,14 +9,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import sopt.comfit.auth.dto.LoginResponseDto;
-import sopt.comfit.auth.dto.ReIssueTokenResponseDto;
+import sopt.comfit.auth.dto.AccessTokenResponseDto;
 import sopt.comfit.auth.dto.request.OnBoardingRequestDTO;
-import sopt.comfit.auth.dto.request.ReIssueTokenRequestDto;
 import sopt.comfit.global.annotation.LoginUser;
 import sopt.comfit.global.dto.CommonApiResponse;
 import sopt.comfit.global.dto.CustomErrorResponse;
@@ -28,7 +24,7 @@ public interface AuthSwagger {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "경험 생성 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ReIssueTokenResponseDto.class))),
+                            schema = @Schema(implementation = AccessTokenResponseDto.class))),
 
             @ApiResponse(responseCode = "403", description = "권한 오류",
                     content = @Content(mediaType = "application/json",
@@ -41,8 +37,9 @@ public interface AuthSwagger {
                             schema = @Schema(implementation = CustomErrorResponse.class)))
     })
     @PostMapping("/re-issued")
-    ReIssueTokenResponseDto reissueToken(
-            @RequestBody @Valid ReIssueTokenRequestDto request
+    AccessTokenResponseDto reissueToken(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
     );
 
     @Operation(summary = "온보딩 ", description = "회원가입 시 필수 정보 입력")
@@ -109,5 +106,8 @@ public interface AuthSwagger {
     })
     @PostMapping("/logout")
     @SecurityRequirement(name = "JWT")
-    void logout(@LoginUser Long userId);
+    void logout(
+            @LoginUser Long userId,
+            HttpServletResponse response
+    );
 }

--- a/src/main/java/sopt/comfit/auth/domain/RefreshTokenRepository.java
+++ b/src/main/java/sopt/comfit/auth/domain/RefreshTokenRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-    Optional<RefreshToken> findByToken(String refreshTokenStr);
 }

--- a/src/main/java/sopt/comfit/auth/dto/AccessTokenResponseDto.java
+++ b/src/main/java/sopt/comfit/auth/dto/AccessTokenResponseDto.java
@@ -1,0 +1,9 @@
+package sopt.comfit.auth.dto;
+
+public record AccessTokenResponseDto(
+        String accessToken
+) {
+    public static AccessTokenResponseDto from(String accessToken) {
+        return new AccessTokenResponseDto(accessToken);
+    }
+}

--- a/src/main/java/sopt/comfit/auth/dto/ReIssueTokenResponseDto.java
+++ b/src/main/java/sopt/comfit/auth/dto/ReIssueTokenResponseDto.java
@@ -1,9 +1,0 @@
-package sopt.comfit.auth.dto;
-
-public record ReIssueTokenResponseDto(
-        String accessToken
-) {
-    public static ReIssueTokenResponseDto from(String accessToken) {
-        return new ReIssueTokenResponseDto(accessToken);
-    }
-}

--- a/src/main/java/sopt/comfit/auth/service/AuthService.java
+++ b/src/main/java/sopt/comfit/auth/service/AuthService.java
@@ -1,19 +1,18 @@
 package sopt.comfit.auth.service;
 
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.comfit.auth.domain.RefreshToken;
 import sopt.comfit.auth.domain.RefreshTokenRepository;
-import sopt.comfit.auth.dto.ReIssueTokenResponseDto;
 import sopt.comfit.auth.dto.command.LoginCommandDto;
 import sopt.comfit.auth.dto.command.OnBoardingCommandDto;
 import sopt.comfit.auth.dto.query.LoginQueryDto;
-import sopt.comfit.auth.dto.request.OnBoardingRequestDTO;
 import sopt.comfit.auth.exception.AuthErrorCode;
 import sopt.comfit.auth.kakao.dto.KakaoUserApiResponseDto;
+import sopt.comfit.global.constants.Constants;
 import sopt.comfit.global.dto.JwtDto;
 import sopt.comfit.global.exception.BaseException;
 import sopt.comfit.global.exception.CommonErrorCode;
@@ -53,27 +52,35 @@ public class AuthService {
         refreshTokenRepository.deleteById(userId.toString());
     }
 
-    public ReIssueTokenResponseDto reissueToken(String refreshTokenStr) {
+    public JwtDto reissueToken(String refreshTokenStr) {
 
-        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenStr)
-                .orElseThrow(() -> {
-                    log.warn("만료된 토큰입니다.");
-                    return BaseException.type(AuthErrorCode.REFRESH_TOKEN_EXPIRATION);
-                });
-
-        try {
-            jwtUtil.validateToken(refreshTokenStr);
-        } catch (Exception e) {
-            log.warn("RefreshToken 검증 실패: {}", e.getMessage());
-            throw BaseException.type(CommonErrorCode.TOKEN_MALFORMED_ERROR);
+        if (refreshTokenStr == null) {
+            throw BaseException.type(CommonErrorCode.REFRESH_TOKEN_EMPTY);
         }
 
-        Long userId = Long.parseLong(refreshToken.getId());
+        Claims claims = jwtUtil.validateToken(refreshTokenStr);
+
+        Long userId = Long.valueOf(claims.get(Constants.CLAIM_USER_ID).toString());
+
+        RefreshToken savedToken = refreshTokenRepository.findById(userId.toString())
+                .orElseThrow(() -> BaseException.type(AuthErrorCode.REFRESH_TOKEN_EXPIRATION));
+
+        if (!savedToken.getToken().equals(refreshTokenStr)) {
+            throw BaseException.type(AuthErrorCode.REFRESH_TOKEN_EXPIRATION);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
 
-        return ReIssueTokenResponseDto.from(jwtUtil.generateAccessToken(userId, user.getRole()));
+        refreshTokenRepository.deleteById(userId.toString());
+
+        JwtDto jwtDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+
+        refreshTokenRepository.save(
+                RefreshToken.issueRefreshToken(user.getId(), jwtDto.refreshToken())
+        );
+
+        return jwtDto;
     }
 
     @Transactional
@@ -111,6 +118,9 @@ public class AuthService {
         );
 
         JwtDto jwtDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+
+        refreshTokenRepository.save(RefreshToken.issueRefreshToken(user.getId(), jwtDto.refreshToken()));
+
         return LoginQueryDto.of(user.getId(), isNew, user.getName(), jwtDto);
     }
 }

--- a/src/main/java/sopt/comfit/global/exception/CommonErrorCode.java
+++ b/src/main/java/sopt/comfit/global/exception/CommonErrorCode.java
@@ -30,6 +30,7 @@ public enum CommonErrorCode implements ErrorCode {
     TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_005", "지원하지않는 토큰입니다."),
     TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_006", "알 수 없는 토큰입니다."),
     AUTHENTICATION_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_007", "인증된 사용자 정보를 찾을 수 없습니다"),
+    REFRESH_TOKEN_EMPTY(HttpStatus.BAD_REQUEST, "AUTH_400_001", "리프레시 토큰이 비어있습니다."),
 
     // ===== 서버 에러 (5xx) =====
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_500_001", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/sopt/comfit/global/security/util/JwtUtil.java
+++ b/src/main/java/sopt/comfit/global/security/util/JwtUtil.java
@@ -1,8 +1,6 @@
 package sopt.comfit.global.security.util;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
@@ -11,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import sopt.comfit.global.constants.Constants;
 import sopt.comfit.global.dto.JwtDto;
+import sopt.comfit.global.exception.BaseException;
+import sopt.comfit.global.exception.CommonErrorCode;
 import sopt.comfit.user.domain.ERole;
 
 import java.security.Key;
@@ -39,11 +39,23 @@ public class JwtUtil implements InitializingBean {
     }
 
     public Claims validateToken(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            throw BaseException.type(CommonErrorCode.EXPIRED_TOKEN_ERROR);
+
+        } catch (UnsupportedJwtException e) {
+            throw BaseException.type(CommonErrorCode.TOKEN_UNSUPPORTED_ERROR);
+
+        } catch (MalformedJwtException e) {
+            throw BaseException.type(CommonErrorCode.TOKEN_MALFORMED_ERROR);
+
+        }
     }
 
     private String generateToken(Long id, ERole role, Integer expiration) {
@@ -68,7 +80,4 @@ public class JwtUtil implements InitializingBean {
         );
     }
 
-    public String generateAccessToken(Long id, ERole role) {
-        return generateToken(id, role, accessExpiration);
-    }
 }


### PR DESCRIPTION
## 📌 요약
 액세스 토큰 재발급 로직에서 발생하는 오류를 수정한다

## 📝 변경 내용
Kakao Login 시 리프레시토큰 저장안하는 것 수정
TTL 수정
Body에서 AccessToken RefreshToken 2개 보내는거 수정
Login Logout ReIssue , KaKao Login 쿠키 저장하고 보내는 로직 수정 
재발급 로직
refreshToken 쿠키로 받고 토큰 ID를 통해서 있는지 확인 , 만료된 토큰인지 확인하고
재발급 (리프레시도 같이 재발급 , 탈취방지)

## ✅ 체크리스트
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## 🗣 의견 / 공유 해야하는 점

## 🚪 연관 이슈 번호
Closes #100 